### PR TITLE
Added keyboard navigation and support for all image nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Custom javascript extensions for better UX for ComfyUI.
 
 ## Image Gallery
 
-Supported nodes: `PreviewImage`, `SaveImage`. Double click on image to open.
+Double click on image to open.
 
 ![tasty-knives-retire-104-198-110-184 loca lt_ (1)](https://user-images.githubusercontent.com/131459485/233774475-de194000-347e-4d75-a9f4-17f84ad735fd.png)


### PR DESCRIPTION
This turned into considerable refactoring unfortunately. However, if all node types are to be supported, the amount of work done per node type should be minimal. So almost all carousel logic has been centralized in the `ComfyCarousel` class. The node type handling is merely overriding `onDblClick` method (not assuming that there wasn’t one before) and checking whether the click went to an image (gallery shouldn’t open if a complex node is clicked in some random spot).

I’ve added a keyboard handler while at it. Switching between images and closing the carousel can be done via keyboard now.